### PR TITLE
[IMP] account_wallet : add no_anonymous feature to force to have only nominative wallets

### DIFF
--- a/account_wallet/models/account_move_line.py
+++ b/account_wallet/models/account_move_line.py
@@ -58,6 +58,12 @@ class AccountMoveLine(models.Model):
                     "wallet_type_id": wallet_type.id,
                 }
             )
+            if wallet_type.no_anonymous:
+                vals.update(
+                    {
+                        "partner_id": values["partner_id"],
+                    }
+                )
         return vals
 
     def wallet_value(self, vals_list):

--- a/account_wallet/models/account_wallet_type.py
+++ b/account_wallet/models/account_wallet_type.py
@@ -46,6 +46,10 @@ class AccountWalletType(models.Model):
         required=True,
     )
 
+    no_anonymous = fields.Boolean(
+        help="Check this box if you want to generate only nominative wallets."
+    )
+
     # TODO: Check if this is necessary and if model cannot be simplified
     # @api.constrains('product_id', 'account_id', 'journal_id')
     # def _check_account(self):

--- a/account_wallet/tests/test_wallet.py
+++ b/account_wallet/tests/test_wallet.py
@@ -13,7 +13,7 @@ class TestWallet(WalletCommon):
             self.wallet.display_name, self.wallet_type.name + " - " + self.wallet.name
         )
 
-    def test_wallet(self):
+    def _test_wallet(self):
         """Buy wallet product
         Check wallet amount
         Pay with wallet
@@ -90,6 +90,17 @@ class TestWallet(WalletCommon):
         )
         self.assertEqual(len(wallet.account_move_line_ids), 2)
         self.assertAlmostEqual(wallet.balance, 0.00, 2)
+        return wallet
+
+    def test_wallet_anonymous(self):
+        self.wallet_type.no_anonymous = False
+        wallet = self._test_wallet()
+        self.assertEqual(wallet.partner_id.id, False)
+
+    def test_wallet_no_anonymous(self):
+        self.wallet_type.no_anonymous = True
+        wallet = self._test_wallet()
+        self.assertEqual(wallet.partner_id.id, self.env.ref("base.res_partner_2").id)
 
     def test_wallet_partner(self):
         """Create wallet with partner

--- a/account_wallet/views/wallet_type.xml
+++ b/account_wallet/views/wallet_type.xml
@@ -47,6 +47,7 @@
                                 name="company_id"
                                 groups="base.group_multi_company"
                             />
+                            <field name="no_anonymous" />
                         </group>
                     </group>
                 </sheet>


### PR DESCRIPTION
see our discussion. (point 3)

CC : @xavier-bouquiaux, @rousseldenis

**Note** : I don't know if users want to have the feature enabled or not, but in doubt, I disabled the new feature, so deploying this patch on your instance will not change the behavior of your site in production.