### PR TITLE
[IMP] account_wallet : add domain on product_id for account_wallet_type, to be consistent with wizard.account_move_credit_notes.wallet product_id field

### DIFF
--- a/account_wallet/models/account_wallet_type.py
+++ b/account_wallet/models/account_wallet_type.py
@@ -39,6 +39,7 @@ class AccountWalletType(models.Model):
         ondelete="restrict",
         help="Product use to fill the wallet",
         required=True,
+        domain="[('type', '=', 'service')]",
     )
     company_id = fields.Many2one(
         comodel_name="res.company",


### PR DESCRIPTION
trivial PR.